### PR TITLE
Fix gitignore spacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,9 @@ inst/include/xsimd
 *.so
 *.dll
 
- # Generated Rcpp artefacts
- R/RcppExports.R
- src/RcppExports.cpp
+# Generated Rcpp artefacts
+R/RcppExports.R
+src/RcppExports.cpp
 
 # Output files from R CMD check
 /*.Rcheck/


### PR DESCRIPTION
Not sure why, but there was a space in the gitignore causing issues with ignoring the Rcpp generated files.